### PR TITLE
Update machines and powerups

### DIFF
--- a/BP/functions/apply_powerups.mcfunction
+++ b/BP/functions/apply_powerups.mcfunction
@@ -1,0 +1,2 @@
+effect @a[tag=speedforu] speed 11 2 true
+effect @a[tag=healthforu] health_boost 11 4 true

--- a/BP/functions/clear_powerups.mcfunction
+++ b/BP/functions/clear_powerups.mcfunction
@@ -1,0 +1,4 @@
+tag @s remove healthforu
+tag @s remove speedforu
+effect @s health_boost 0
+effect @s speed 0

--- a/BP/functions/powerups.mcfunction
+++ b/BP/functions/powerups.mcfunction
@@ -1,4 +1,0 @@
-effect @a[tag=speedforu] speed 2 2 true
-effect @a[tag=healthforu] health_boost 2 4 true
-effect @a[tag=healthforu, tag=!healthforu_healed] instant_health 1 255
-tag @a[tag=healthforu, tag=!healthforu_healed] add healthforu_healed

--- a/BP/functions/speed_for_u.mcfunction
+++ b/BP/functions/speed_for_u.mcfunction
@@ -1,9 +1,0 @@
-tellraw @s[tag=speedforu] {"rawtext":[{"text":"[SpeedForU] You already have this!"}]}
-
-tellraw @s[scores={money=0..2499},tag=!speedforu] {"rawtext":[{"text":"[SpeedForU] You don't have enough for this!"}]}
-
-tellraw @s[scores={money=2500..100000},tag=!speedforu] {"rawtext":[{"text":"[SpeedForU] You successfully bought §6Speed For U!"}]}
-
-scoreboard players remove @s[scores={money=2500..100000},tag=!speedforu] money 2500
-
-tag @s[scores={money=2500..100000},tag=!speedforu] add speedforu

--- a/BP/functions/tick.json
+++ b/BP/functions/tick.json
@@ -1,7 +1,7 @@
 {
 	"values": [
-		"start",
-		"powerups",
-		"dead"
+		"apply_powerups",
+		"dead",
+		"start"
 	]
 }

--- a/BP/scripts/powerups.js
+++ b/BP/scripts/powerups.js
@@ -1,33 +1,28 @@
-import { world } from 'mojang-minecraft'
-
-import {
-    ActionFormData,
-    MessageFormData,
-    ModalFormData
-} from "mojang-minecraft-ui"
+import { world, SoundOptions, MolangVariableMap, Color } from 'mojang-minecraft'
+import { ActionFormData } from 'mojang-minecraft-ui'
 
 world.events.tick.subscribe(tick => {
     const players = world.getPlayers()
 
     for (let player of players) {
-        const dimension = world.getDimension(player.dimension.id)
-
         if (player.hasTag("speedbuy")) {
             player.removeTag("speedbuy")
 
-            const speedForm = new MessageFormData()
+            const speedForm = new ActionFormData()
 
                 .title("Speed For U")
+                .body("Get quick! Buy some Speed For U!")
 
-                .body("Get Quick! Buy some Speed For U!")
-
-                .button1("Buy ($2500)")
-
-                .button2("Not Now")
+                .button("Buy ($2500)")
+                .button("Not Now")
 
             speedForm.show(player).then(formData => {
-                if (formData.selection === 1) {
-                    player.runCommand('function speed_for_u')
+                if (formData.selection === 0) {
+                    const purchaseOptions = {
+                        particleColor: [124, 175, 198]
+                    }
+
+                    purchasePowerup(player, 2500, 'Speed For U', purchaseOptions)
                 }
             })
         }
@@ -39,46 +34,87 @@ world.events.tick.subscribe(tick => {
             player.removeTag("healthbuy")
 
             const cost = player.hasTag('healthforu') ? 1800 : 900
+            const health = player.getComponent('minecraft:health')
 
-            const healthForm = new MessageFormData()
+            const healthForm = new ActionFormData()
 
                 .title("Health For U")
 
-                .body("Get Quick! Buy some Health For U!")
+                .body("Stay up against those monsters! Buy some Health For U!")
 
-                .button1(`Heal (\$${cost})`)
-
-                .button2("Upgrade ($3500)")
+                .button(`Heal (\$${cost})`)
+                .button("Upgrade ($3500)")
+                .button("Not Now")
 
             healthForm.show(player).then(formData => {
-                const money = world.scoreboard.getObjective('money').getScore(player.scoreboard)
-
-                if (formData.selection === 1) {
-                    if (money < cost) {
-                        player.runCommand(`tellraw @s {"rawtext":[{"text":"[HealthForU] You don't have enough for this!"}]}`)
-
-                        return
+                if (formData.selection === 0) {
+                    const purchaseOptions = {
+                        assignTag: false,
+                        duplicateCondition: (Math.ceil(health.current) >= health.value + player.hasTag("healthforu") * 20),
+                        duplicateMessage: 'You already have maximum health!',
+                        particleColor: [248, 36, 35]
                     }
+                    const purchaseSuccess = purchasePowerup(player, cost, 'Health For U', purchaseOptions)
 
-                    player.runCommand(`tellraw @s {"rawtext":[{"text":"[HealthForU] You successfully bought §6Health For U!"}]}`)
-
-                    player.runCommand(`scoreboard players remove @s money ${cost}`)
-
-                    player.runCommand(`effect @s instant_health 1 255`)
-                } else if (formData.selection === 0) {
-                    if (money < 3500) {
-                        player.runCommand(`tellraw @s {"rawtext":[{"text":"[HealthForU] You don't have enough for this!"}]}`)
-
-                        return
+                    if (purchaseSuccess) {
+                        health.resetToMaxValue()
                     }
+                } else if (formData.selection === 1) {
+                    const purchaseOptions = {
+                        particleColor: [248, 125, 35]
+                    }
+                    const purchaseSuccess = purchasePowerup(player, 3500, 'Health For U', purchaseOptions)
 
-                    player.runCommand(`tellraw @s {"rawtext":[{"text":"[HealthForU] You successfully bought §6Health For U!"}]}`)
-
-                    player.runCommand(`scoreboard players remove @s money 3500`)
-
-                    player.runCommand(`tag @s add healthforu`)
+                    if (purchaseSuccess) {
+                        health.setCurrent(40)
+                    }
                 }
             })
         }
     }
 })
+
+/**
+* @param {Player} player
+* @param {number} cost
+* @param {string} powerup
+* @param {object} purchaseOptions
+*/
+function purchasePowerup(player, cost, powerup, purchaseOptions = {}) {
+    const dimension = player.dimension
+    const duplicateMessage = (purchaseOptions.duplicateMessage == undefined) ? 'You already have this!' : purchaseOptions.duplicateMessage
+    const identifier = powerup.replace(/ /g, '')
+    const ignoreTag = !(purchaseOptions.assignTag || purchaseOptions.assignTag == undefined)
+    const money = world.scoreboard.getObjective('money').getScore(player.scoreboard)
+    let soundOptions = new SoundOptions()
+    soundOptions.location = player.location
+
+    if (money < cost) {
+        player.runCommand(`tellraw @s {"rawtext":[{"text":"[${identifier}] You don\'t have enough for this!"}]}`)
+
+        return false
+    } else if ((player.hasTag(identifier.toLocaleLowerCase()) && !ignoreTag) || purchaseOptions.duplicateCondition) {
+        player.runCommand(`tellraw @s {"rawtext":[{"text":"[${identifier}] ${duplicateMessage}"}]}`)
+
+        return false
+    }
+
+    player.runCommand(`tellraw @s {"rawtext":[{"text":"[${identifier}] You successfully bought §6${powerup}§r!"}]}`)
+    player.runCommand(`scoreboard players remove @s money ${cost}`)
+
+    player.playSound("beacon.power", soundOptions)
+
+    if (!ignoreTag) {
+        player.addTag(identifier.toLocaleLowerCase())
+    }
+
+    if (purchaseOptions.particleColor != undefined) {
+        const particleColor = new Color(purchaseOptions.particleColor[0] / 255, purchaseOptions.particleColor[1] / 255, purchaseOptions.particleColor[2] / 255, 1)
+        let particleVariableMap = new MolangVariableMap()
+        particleVariableMap.setColorRGBA("variable.color", particleColor)
+
+        dimension.spawnParticle("home:powerup_particle", player.location, particleVariableMap)
+    }
+
+    return true
+}

--- a/RP/particles/powerup.json
+++ b/RP/particles/powerup.json
@@ -1,0 +1,64 @@
+{
+	"format_version": "1.10.0",
+	"particle_effect": {
+		"description": {
+			"identifier": "home:powerup_particle",
+			"basic_render_parameters": {
+				"material": "particles_alpha",
+				"texture": "textures/particle/particles"
+			}
+		},
+		"components": {
+			"minecraft:emitter_local_space": {
+				"position": true,
+				"rotation": false
+			},
+			"minecraft:emitter_rate_instant": {
+				"num_particles": 8
+			},
+			"minecraft:emitter_lifetime_once": {
+				"active_time": 0.15
+			},
+			"minecraft:emitter_shape_box": {
+				"offset": [0, 0.9, 0],
+				"half_dimensions": [0.6, 0.9, 0.6],
+				"surface_only": true,
+				"direction": ["Math.random(-0.25, 0.25)", "Math.random(0, 1)", "Math.random(-0.25, 0.25)"]
+			},
+			"minecraft:particle_lifetime_expression": {
+				"max_lifetime": "Math.random(0.85, 1.35)"
+			},
+			"minecraft:particle_initial_speed": "(Math.random(0, 1) + Math.random(0, 1) + 1) * 0.55",
+			"minecraft:particle_motion_dynamic": {
+				"linear_acceleration": ["(variable.particle_random_1 * 2 - 1)*0.5 - (variable.particle_age * 0.4) * 2.5", "1 + (0.08 * variable.particle_age) - (variable.particle_age * 0.4) * 1.5", "(variable.particle_random_2 * 2 - 1)*0.5 - (variable.particle_age * 0.4) * 2.5"]
+			},
+			"minecraft:particle_appearance_billboard": {
+				"size": [0.125, 0.125],
+				"facing_camera_mode": "lookat_xyz",
+				"uv": {
+					"texture_width": 128,
+					"texture_height": 128,
+					"flipbook": {
+						"base_UV": [64, 64],
+						"size_UV": [8, 8],
+						"step_UV": [-8, 0],
+						"frames_per_second": 10,
+						"max_frame": 8,
+						"stretch_to_lifetime": true
+					}
+				}
+			},
+			"minecraft:particle_motion_collision": {
+				"enabled": 1,
+				"collision_drag": 1,
+				"coefficient_of_restitution": 1,
+				"collision_radius": 0.01,
+				"expire_on_contact": true
+			},
+			"minecraft:particle_appearance_lighting": {},
+			"minecraft:particle_appearance_tinting": {
+				"color": ["Math.clamp(variable.color.r, 0, 1)", "Math.clamp(variable.color.g, 0, 1)", "Math.clamp(variable.color.b, 0, 1)", 1]
+			}
+		}
+	}
+}


### PR DESCRIPTION
"Commands? In MY GameTest?"
- Rename "powerups" function to "apply_powerups"
- Add function to clear powerups (currently for testing)
- Increase length of powerups from 2 to 11 seconds
- Update machine descriptions
- Add cancel button to Health For U machine
- Players can no longer heal at maximum health
- Players can no longer purchase multiple Health For U powerups
- Beacon power sound and new particle effects play when purchasing from a machine