### PR TITLE
Update functions and kill counter

### DIFF
--- a/BP/functions/dead.mcfunction
+++ b/BP/functions/dead.mcfunction
@@ -1,6 +1,5 @@
-gamemode spectator @a[tag=dead]
+gamemode spectator @a[m=!spectator,tag=dead]
 
-clear @a[tag=expired]
-tag @a[tag=expired] remove joined
+execute as @a[tag=expired] run function reset_player
 tag @a[tag=expired] remove dead
 tag @a[tag=expired] remove expired

--- a/BP/functions/reset_player.mcfunction
+++ b/BP/functions/reset_player.mcfunction
@@ -1,0 +1,8 @@
+clear @s
+function clear_powerups
+gamemode adventure
+loot give @s loot start
+scoreboard players set @s killCount 0
+scoreboard players set @s money 250
+tp -168 -60 37
+xp -100l @s

--- a/BP/functions/start.mcfunction
+++ b/BP/functions/start.mcfunction
@@ -1,19 +1,10 @@
-scoreboard objectives add killCount dummy
+scoreboard objectives add killCount dummy "Kill Count"
 scoreboard objectives add money dummy Money
+scoreboard objectives setdisplay belowname money
+scoreboard objectives setdisplay list killCount
 scoreboard objectives setdisplay sidebar money
 
-scoreboard objectives setdisplay belowname money
-
-execute as @a run titleraw @s actionbar {"rawtext":[{"text": "Kill Count: "},{"score":{"name":"@s","objective":"killCount"}}]}
-
-scoreboard players set @a[tag=!joined] money 250
-scoreboard players set @a[tag=!joined] killCount 0
-tp @a[tag=!joined] -168 -60 37
-xp -100l @a[tag=!joined]
-gamemode adventure @a[tag=!joined]
-loot give @a[tag=!joined] loot start
-tag @a[tag=!joined] remove speedforu
-tag @a[tag=!joined] remove healthforu
+execute as @a[tag=!joined] run function reset_player
 tag @a[tag=!joined] add joined
 
 effect @a saturation 1 1 true


### PR DESCRIPTION
- Killed players are sent a single message when entering spectator mode
- Cleaned up commands for respawning
- Kill count is now displayed in the player list
- Players' kill counts are no longer displayed as action bars